### PR TITLE
Revert "[TECH] Removing args field when formatting message"

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -70,7 +70,6 @@ class LogstashFormatter(logging.Formatter):
         fields = record.__dict__.copy()
         fields.pop('msg', None)
         fields.pop('message', None)
-        fields.pop('args', None)
 
         if 'exc_info' in fields:
             if fields['exc_info']:

--- a/tests/test_normal_case.py
+++ b/tests/test_normal_case.py
@@ -81,7 +81,8 @@ class Test(TestCase):
         self.log.debug('spam')
         self.assertEqualDiff(
             json.loads(self.stream.getvalue()),
-            {'@fields': 'created': 1496407610.9405103,
+            {'@fields': {'args': [],
+                         'created': 1496407610.9405103,
                          'filename': 'test_normal_case.py',
                          'funcName': 'test',
                          'levelname': 'DEBUG',


### PR DESCRIPTION
This reverts commit 7b550554434df36eea2a48fd7b1cb212980498ba.